### PR TITLE
Remove dependencies on external adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'griddler', github: 'thoughtbot/griddler'
-gem "griddler-sendgrid", github: "thoughtbot/griddler-sendgrid"
-gem "griddler-mandrill", github: "wingrunr21/griddler-mandrill"
 
 gemspec


### PR DESCRIPTION
Griddler has removed its dependency on these gems, so you don't need to have
it here anymore.
