### PR TITLE
update from field to reply-to if exists, added message-url into messa…

### DIFF
--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -29,7 +29,8 @@ module Griddler
     private
 
       def determine_sender
-        sender = param_or_header(:From)
+        sender = param_or_header("Reply-To")
+        sender ||= param_or_header(:From)
         sender ||= params[:sender]
       end
 
@@ -54,6 +55,7 @@ module Griddler
           parsed_headers = JSON.parse(params['message-headers'])
           parsed_headers.each{ |h| extracted_headers[h[0]] = h[1] }
         end
+        extracted_headers["message-url"] = params["message-url"]
         ActiveSupport::HashWithIndifferentAccess.new(extracted_headers)
       end
 

--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -82,7 +82,11 @@ module Griddler
       end
 
       def attachment_files
-        attachments = JSON.parse(params["attachments"]) || Array.new
+        if params["attachments"].present?
+          attachments = JSON.parse(params["attachments"])
+        else  
+          attachments = Array.new
+        end
         attachments.map do |attachment|
           ActionDispatch::Http::UploadedFile.new(
             {

--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -22,7 +22,7 @@ module Griddler
           text: params['body-plain'],
           html: params['body-html'],
           attachments: attachment_files,
-          headers: serialized_headers
+          headers: headers
         }
       end
 
@@ -84,7 +84,7 @@ module Griddler
       def attachment_files
         if params["attachments"].present?
           attachments = JSON.parse(params["attachments"])
-        else  
+        else
           attachments = Array.new
         end
         attachments.map do |attachment|
@@ -101,7 +101,7 @@ module Griddler
       def create_tempfile(attachment)
         tempfile = Tempfile.new(attachment["name"])
         tempfile.binmode
-        tempfile << open(attachment["url"], 
+        tempfile << open(attachment["url"],
           :http_basic_authentication => ["api", Rails.configuration.apikey]).read
         tempfile.rewind
         tempfile

--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -82,20 +82,23 @@ module Griddler
       end
 
       def attachment_files
-        attachments = JSON.parse(params['attachments']) || Array.new
+        attachments = JSON.parse(params["attachments"]) || Array.new
         attachments.map do |attachment|
-          ActionDispatch::Http::UploadedFile.new({
-            filename: attachment["name"],
-            type: attachment["content-type"],
-            tempfile: create_tempfile(attachment)
-          })
+          ActionDispatch::Http::UploadedFile.new(
+            {
+              filename: attachment["name"],
+              type: attachment["content-type"],
+              tempfile: create_tempfile(attachment)
+            }
+          )
         end
       end
 
       def create_tempfile(attachment)
         tempfile = Tempfile.new(attachment["name"])
         tempfile.binmode
-        tempfile << open(attachment["url"], :http_basic_authentication => ["api", Rails.configuration.apikey]).read
+        tempfile << open(attachment["url"], 
+          :http_basic_authentication => ["api", Rails.configuration.apikey]).read
         tempfile.rewind
         tempfile
       end


### PR DESCRIPTION
sometimes email has a reply to field, which is lost after the normalization. I replaced to field with the value from reply-to. 
also the message-url field is lost as well after the normalization. I included it in the headers. 

please let me know if anything else I need to change.
