### PR TITLE
handle store action attachment format

### DIFF
--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -87,7 +87,7 @@ module Griddler
             params.delete("attachment-#{index+1}")
           end
         else
-          params['attachments']
+          params['attachments'] || []
         end
       end
     end

--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -80,10 +80,14 @@ module Griddler
       end
 
       def attachment_files
-        attachment_count = params['attachment-count'].to_i
+        if params['attachment-count'].present?
+          attachment_count = params['attachment-count'].to_i
 
-        attachment_count.times.map do |index|
-          params.delete("attachment-#{index+1}")
+          attachment_count.times.map do |index|
+            params.delete("attachment-#{index+1}")
+          end
+        else
+          params['attachments']
         end
       end
     end

--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -80,14 +80,14 @@ module Griddler
       end
 
       def attachment_files
-        if params['attachment-count'].present?
-          attachment_count = params['attachment-count'].to_i
+        if params["attachment-count"].present?
+          attachment_count = params["attachment-count"].to_i
 
           attachment_count.times.map do |index|
             params.delete("attachment-#{index+1}")
           end
         else
-          params['attachments'] || []
+          params["attachments"] || []
         end
       end
     end

--- a/spec/griddler/mailgun/adapter_spec.rb
+++ b/spec/griddler/mailgun/adapter_spec.rb
@@ -32,7 +32,7 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
 
   it "receives attachments sent from store action" do
     params = default_params.merge(
-      'attachments' => [{ url: "sample.url", name: "sample name" }, 
+      "attachments" => [{ url: "sample.url", name: "sample name" },
                         { url: "sample2.url", name: "sample name 2" }]
     )
     normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)

--- a/spec/griddler/mailgun/adapter_spec.rb
+++ b/spec/griddler/mailgun/adapter_spec.rb
@@ -30,9 +30,10 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
     expect(normalized_params[:attachments]).to eq [upload_1, upload_2]
   end
 
-  it 'receives attachments sent from store action' do
+  it "receives attachments sent from store action" do
     params = default_params.merge(
-      'attachments' => [{ url: 'sample.url', name: 'sample name' }, { url: 'sample2.url', name: 'sample name 2' }]
+      'attachments' => [{ url: "sample.url", name: "sample name" }, 
+                        { url: "sample2.url", name: "sample name 2" }]
     )
     normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
     expect(normalized_params[:attachments].length).to eq 2

--- a/spec/griddler/mailgun/adapter_spec.rb
+++ b/spec/griddler/mailgun/adapter_spec.rb
@@ -30,6 +30,14 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
     expect(normalized_params[:attachments]).to eq [upload_1, upload_2]
   end
 
+  it 'receives attachments sent from store action' do
+    params = default_params.merge(
+      'attachments' => [{ url: 'sample.url', name: 'sample name' }, { url: 'sample2.url', name: 'sample name 2' }]
+    )
+    normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
+    expect(normalized_params[:attachments].length).to eq 2
+  end
+
   it 'has no attachments' do
     normalized_params = Griddler::Mailgun::Adapter.normalize_params(default_params)
     expect(normalized_params[:attachments]).to be_empty


### PR DESCRIPTION
the post from the store action does not have an attachment-count parameter.  instead, the parameter is 'attachments' and it holds an array of urls, among other things, to pull down the files from a mailgun server