### PR TITLE
add original_recipient to adapter params

### DIFF
--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -22,7 +22,8 @@ module Griddler
           text: params['body-plain'],
           html: params['body-html'],
           attachments: attachment_files,
-          headers: serialized_headers
+          headers: serialized_headers,
+          original_recipient: params[:recipient]
         }
       end
 

--- a/spec/griddler/mailgun/adapter_spec.rb
+++ b/spec/griddler/mailgun/adapter_spec.rb
@@ -98,6 +98,11 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
     expect(normalized_params[:bcc]).to eq []
   end
 
+  it 'includes recipient as original_recipient' do
+    normalized_params = Griddler::Mailgun::Adapter.normalize_params(default_params)
+    expect(normalized_params[:original_recipient]).to eq "johndoe@example.com"
+  end
+
   def upload_1
     @upload_1 ||= ActionDispatch::Http::UploadedFile.new(
       filename: 'photo1.jpg',


### PR DESCRIPTION
`original_recipient` can be useful when `To` doesn't contain email addresses, but ie. `undisclosed-recipients:;`