### PR TITLE
Add vendor_specific params

### DIFF
--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -24,9 +24,9 @@ module Griddler
           attachments: attachment_files,
           headers: serialized_headers,
           vendor_specific: {
-            stripped_text: params['stripped-text'],
-            stripped_signature: params['stripped-signature'],
-            stripped_html: params['stripped-html']
+            stripped_text: params["stripped-text"],
+            stripped_signature: params["stripped-signature"],
+            stripped_html: params["stripped-html"]
           }
         }
       end

--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -22,7 +22,12 @@ module Griddler
           text: params['body-plain'],
           html: params['body-html'],
           attachments: attachment_files,
-          headers: serialized_headers
+          headers: serialized_headers,
+          vendor_specific: {
+            stripped_text: params['stripped-text'],
+            stripped_signature: params['stripped-signature'],
+            stripped_html: params['stripped-html']
+          }
         }
       end
 

--- a/spec/griddler/mailgun/adapter_spec.rb
+++ b/spec/griddler/mailgun/adapter_spec.rb
@@ -93,22 +93,31 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
     expect(normalized_params[:bcc]).to eq ['bcc@example.com']
   end
 
-  it 'adds stripped-signature as a vendor specific param' do
+  it "adds stripped-signature as a vendor specific param" do
     params = default_params.merge(
-      "stripped-signature" => "The Lannisters send their regards",
+      "stripped-signature" => "The Lannisters send their regards"
     )
     normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
-    expect(normalized_params[:vendor_specific][:stripped_signature]).to eq "The Lannisters send their regards"
+    expect(normalized_params[:vendor_specific][:stripped_signature])
+      .to eq "The Lannisters send their regards"
   end
 
-  it 'adds stripped-text as a vendor specific param' do
-    normalized_params = Griddler::Mailgun::Adapter.normalize_params(default_params)
-    expect(normalized_params[:vendor_specific][:stripped_text]).to eq "And attachments. Two of them. An image and a text file."
+  it "adds stripped-text as a vendor specific param" do
+    params = default_params.merge(
+      "stripped-text" => "Lorem ipsum dolor sit amet."
+    )
+    normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
+    expect(normalized_params[:vendor_specific][:stripped_text])
+      .to eq "Lorem ipsum dolor sit amet."
   end
 
-  it 'adds stripped-html as a vendor specific param' do
-    normalized_params = Griddler::Mailgun::Adapter.normalize_params(default_params)
-    expect(normalized_params[:vendor_specific][:stripped_html]).to eq "<div dir=\"ltr\">And attachments. Two of them. An image and a text file.</div>\r\n"
+  it "adds stripped-html as a vendor specific param" do
+    params = default_params.merge(
+      "stripped-html" => "<div>Lorem ipsum dolor sit amet.</div>"
+    )
+    normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
+    expect(normalized_params[:vendor_specific][:stripped_html])
+      .to eq "<div>Lorem ipsum dolor sit amet.</div>"
   end
 
   it 'bcc is empty array when it missing' do

--- a/spec/griddler/mailgun/adapter_spec.rb
+++ b/spec/griddler/mailgun/adapter_spec.rb
@@ -93,6 +93,24 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
     expect(normalized_params[:bcc]).to eq ['bcc@example.com']
   end
 
+  it 'adds stripped-signature as a vendor specific param' do
+    params = default_params.merge(
+      "stripped-signature" => "The Lannisters send their regards",
+    )
+    normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
+    expect(normalized_params[:vendor_specific][:stripped_signature]).to eq "The Lannisters send their regards"
+  end
+
+  it 'adds stripped-text as a vendor specific param' do
+    normalized_params = Griddler::Mailgun::Adapter.normalize_params(default_params)
+    expect(normalized_params[:vendor_specific][:stripped_text]).to eq "And attachments. Two of them. An image and a text file."
+  end
+
+  it 'adds stripped-html as a vendor specific param' do
+    normalized_params = Griddler::Mailgun::Adapter.normalize_params(default_params)
+    expect(normalized_params[:vendor_specific][:stripped_html]).to eq "<div dir=\"ltr\">And attachments. Two of them. An image and a text file.</div>\r\n"
+  end
+
   it 'bcc is empty array when it missing' do
     normalized_params = Griddler::Mailgun::Adapter.normalize_params(default_params)
     expect(normalized_params[:bcc]).to eq []

--- a/spec/griddler/mailgun/adapter_spec.rb
+++ b/spec/griddler/mailgun/adapter_spec.rb
@@ -98,8 +98,8 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
       "stripped-signature" => "The Lannisters send their regards"
     )
     normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
-    expect(normalized_params[:vendor_specific][:stripped_signature])
-      .to eq "The Lannisters send their regards"
+    expect(normalized_params[:vendor_specific][:stripped_signature]).
+      to eq "The Lannisters send their regards"
   end
 
   it "adds stripped-text as a vendor specific param" do
@@ -107,8 +107,8 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
       "stripped-text" => "Lorem ipsum dolor sit amet."
     )
     normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
-    expect(normalized_params[:vendor_specific][:stripped_text])
-      .to eq "Lorem ipsum dolor sit amet."
+    expect(normalized_params[:vendor_specific][:stripped_text]).
+      to eq "Lorem ipsum dolor sit amet."
   end
 
   it "adds stripped-html as a vendor specific param" do
@@ -116,8 +116,8 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
       "stripped-html" => "<div>Lorem ipsum dolor sit amet.</div>"
     )
     normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
-    expect(normalized_params[:vendor_specific][:stripped_html])
-      .to eq "<div>Lorem ipsum dolor sit amet.</div>"
+    expect(normalized_params[:vendor_specific][:stripped_html]).
+      to eq "<div>Lorem ipsum dolor sit amet.</div>"
   end
 
   it 'bcc is empty array when it missing' do


### PR DESCRIPTION
We needed a way to get at the signature that Mailgun automatically strips from the email text. Griddler recently added the ability to include vendor specific params in [this PR](https://github.com/thoughtbot/griddler/pull/285) which makes that possible. This passes through a few of those:

* `stripped_signature`
* `stripped_text`
* `stripped_html`

Mailgun uses kebab-case for the parameters, but I'm converting them to snake-case here to align with  ruby conventions -- I'm not entirely sure if that's preferred or not, so I'm happy to change it up.