### PR TITLE
add recipient as a vendor specific param

### DIFF
--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -26,7 +26,8 @@ module Griddler
           vendor_specific: {
             stripped_text: params["stripped-text"],
             stripped_signature: params["stripped-signature"],
-            stripped_html: params["stripped-html"]
+            stripped_html: params["stripped-html"],
+            recipient: params["recipient"]
           }
         }
       end

--- a/spec/griddler/mailgun/adapter_spec.rb
+++ b/spec/griddler/mailgun/adapter_spec.rb
@@ -120,6 +120,11 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
       to eq "<div>Lorem ipsum dolor sit amet.</div>"
   end
 
+  it "adds recipient as a vendor specific param" do
+    normalized_params = Griddler::Mailgun::Adapter.normalize_params(default_params)
+    expect(normalized_params[:vendor_specific][:recipient]).to eq "johndoe@example.com"
+  end
+
   it 'bcc is empty array when it missing' do
     normalized_params = Griddler::Mailgun::Adapter.normalize_params(default_params)
     expect(normalized_params[:bcc]).to eq []


### PR DESCRIPTION
Follow up to https://github.com/bradpauly/griddler-mailgun/pull/21

Adds `recipient` as a vendor-specific param to handle `undisclosed-recipients:;` emails