### PR TITLE
Update README with example params submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,38 @@ Action:
 forward("http://example.com/email_processor")
 ```
 
+#### Notes on testing
+
+If you want to test the functionality of the route, via `rspec` or `minitest` or in Postman, please note that the `to`, `from`, `bcc` and `cc` params you post _must_ be capitalized:
+
+This would _not_ work:
+
+```json
+{
+	"recipient": "recipient@domain.com",
+	"from": "this wont work <whywontyouwork@working.foo>",
+	"to": "to@domain.com",
+	"subject": "griddler-mailgun",
+	"body-plain": "This is some text body",
+	"body-html": "Supports <em>HTML</em> as well."
+}
+```
+
+On the other hand, this would:
+
+```json
+{
+	"recipient": "recipient@domain.com",
+	"From": "this wont work <whywontyouwork@working.foo>",
+	"To": "to@domain.com",
+	"subject": "griddler-mailgun",
+	"body-plain": "This is some text body",
+	"body-html": "Supports <em>HTML</em> as well."
+}
+```
+You can explore the expected fields and capitalizations in the [`Griddler::Mailgun::Adapter#normalize_params`](https://github.com/bradpauly/griddler-mailgun/blob/master/lib/griddler/mailgun/adapter.rb#L15) method. 
+
+
 ## More Information
 
 * [mailgun](http://www.mailgun.com)


### PR DESCRIPTION
As outlined in https://github.com/bradpauly/griddler-mailgun/issues/19, `griddler-mailgun` will fail to parse params in some situations. 

We can see the expected params here: 

https://github.com/bradpauly/griddler-mailgun/blob/master/lib/griddler/mailgun/adapter.rb#L15

It can be tricky, because `griddler-mailgun` expects a key for `To`, but if it receives `to`, it will fail to grab the param.

I'm happy to make a PR that updates the behavior of `griddler-mailgun`, so it's case-insensitive. I didn't want to presume too much, so I thought a quick documentation update might save someone else down the road a few hours.

This PR is at odds with #28; if this PR is accepted, #28 should be closed, and vice versa. 
